### PR TITLE
[ALLI-7569] Drop PHP 7.4 Support & Prep for a 6.0 Release

### DIFF
--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -1,0 +1,37 @@
+name: Setup PHP
+
+description: Set up PHP & Composer
+
+inputs:
+  php-version:
+    required: false
+    type: string
+    description: the php version to use, defaults to 8.2
+    default: '8.2'
+
+runs:
+  using: composite
+  steps:
+      - name: PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ inputs.php-version }}"
+          tools: composer
+          coverage: xdebug
+          ini-values: zend.assertions=1,assert.exception=1,xdebug.mode=coverage
+
+      - name: composer cache
+        id: composercache
+        shell: bash
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: cache php dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ inputs.php-version }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-${{ inputs.php-version }}-
+
+      - name: install php dependencies
+        shell: bash
+        run: composer install --no-interaction --no-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  test:
+    name: test
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      matrix:
+        include:
+          - php-version: 8.0
+          - php-version: 8.1
+          - php-version: 8.2
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: start localstack
+        run: ./bin/dev/up
+      - name: PHP
+        uses: ./.github/actions/setup-php
+        with:
+          php-version: "${{ matrix.php-version }}"
+      - name: tests
+        run: ./bin/dev/unittest

--- a/bin/dev/down
+++ b/bin/dev/down
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+pushd "$(git rev-parse --show-toplevel)"
+
+exec docker-compose down

--- a/bin/dev/unittest
+++ b/bin/dev/unittest
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+pushd "$(git rev-parse --show-toplevel)"
+
+./bin/dev/wait_for_localstack
+
+exec php vendor/bin/phpunit -v

--- a/bin/dev/up
+++ b/bin/dev/up
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+pushd "$(git rev-parse --show-toplevel)"
+
+rm -f var/localstack/ready
+
+exec docker-compose up -d

--- a/bin/dev/wait_for_localstack
+++ b/bin/dev/wait_for_localstack
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+count=0
+found="no"
+while [ "$count" -lt 5 ]; do
+    if [ -f "./var/localstack/ready" ]; then
+        found="yes"
+        break
+    fi
+
+    echo "waiting for localstack"
+    sleep 5
+    count=$((count+1))
+done
+
+if [ "$found" = "yes" ]; then
+    exit 0
+else
+    echo "localstack did not start up in time"
+    exit 1
+fi

--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,15 @@
         { "name": "Christopher Davis", "email": "chris@pmg.com" }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
-        "pmg/queue": "^5.0",
-        "psr/log": "^1.0",
+        "php": "^8.0",
+        "pmg/queue": "^6.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "aws/aws-sdk-php": "^3.0"
     },
     "require-dev": {
-        "pmg/queue": "^5.0@beta",
-        "phpunit/phpunit": "^9.5"
+        "pmg/queue": "^6.0@beta",
+        "phpunit/phpunit": "^9.5",
+        "symfony/phpunit-bridge": "^5.4"
     },
     "autoload": {
         "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  localstack:
+    image: localstack/localstack:1.3.1
+    ports:
+      - "4566:4566"
+    environment:
+      - LOCALSTACK_SERVICES=cloudwatch
+    volumes:
+      - ./var/localstack:/var/lib/localstack
+      - ./docker/localstack/ready.d:/etc/localstack/init/ready.d

--- a/docker/localstack/ready.d/999-done.sh
+++ b/docker/localstack/ready.d/999-done.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "READY" > /var/lib/localstack/ready

--- a/src/Metric.php
+++ b/src/Metric.php
@@ -15,12 +15,21 @@ namespace PMG\Queue\CloudWatch;
 
 final class Metric
 {
-    private $name;
-    private $value;
-    private $unit;
-    private $dimensions;
+    private string $name;
 
-    public function __construct($name, $value, $unit, array $dimensions=[])
+    private int|float $value;
+
+    private string $unit;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $dimensions;
+
+    /**
+     * @param array<string, string> $dimensions
+     */
+    public function __construct(string $name, int|float $value, string $unit, array $dimensions=[])
     {
         $this->name = $name;
         $this->value = $value;
@@ -28,17 +37,26 @@ final class Metric
         $this->dimensions = $dimensions;
     }
 
-    public static function count($name, $value, array $dimensions=[])
+    /**
+     * @param array<string, string> $dimensions
+     */
+    public static function count(string $name, int $value, array $dimensions=[]) : self
     {
         return new self($name, $value, 'Count', $dimensions);
     }
 
-    public static function millis($name, $value, array $dimensions=[])
+    /**
+     * @param array<string, string> $dimensions
+     */
+    public static function millis(string $name, float $value, array $dimensions=[]) : self
     {
         return new self($name, $value, 'Milliseconds', $dimensions);
     }
 
-    public function toClientArray(array $dimensions=[])
+    /**
+     * @return array<string, mixed>
+     */
+    public function toClientArray(array $dimensions=[]) : array
     {
         return [
             'MetricName' => $this->name,
@@ -51,13 +69,17 @@ final class Metric
         ];
     }
 
-    private static function toClientDimensions(array $kvs)
+    /**
+     * @return array<string, string> $kvs
+     * @return array<int, array<string, string>>
+     */
+    private static function toClientDimensions(array $kvs) : array
     {
         $out = [];
         foreach ($kvs as $name => $value) {
             $out[] = [
                 'Name' => $name, 
-                'Value' => self::limitString($value),
+                'Value' => self::limitDimensionValueString($value),
             ];
         }
 
@@ -65,12 +87,12 @@ final class Metric
     }
 
     /**
-     * Cloudwatch only allows 255 characters for dimension names and values. This
+     * Cloudwatch only allows 1024 characters for dimension names and values. This
      * ensures that the content for those values from users is limited to an
      * appropriate length.
      */
-    private static function limitString($in)
+    private static function limitDimensionValueString($in) : string
     {
-        return substr($in, 0, 255);
+        return substr($in, 0, 1024);
     }
 }

--- a/test/MetricsDriverIntegrationTest.php
+++ b/test/MetricsDriverIntegrationTest.php
@@ -23,7 +23,7 @@ class MetricsDriverIntegrationTest extends TestCase
     private CloudWatchClient $cloudwatch;
     private MetricsDriver $driver;
 
-    public function testDriverErrorsAreTrackedWithMetrics()
+    public function testDriverErrorsAreTrackedWithMetrics() : void
     {
         $this->driverThrowsFrom('enqueue');
 
@@ -34,7 +34,7 @@ class MetricsDriverIntegrationTest extends TestCase
         }
     }
 
-    public function testEnqueuePutsMessageEnqueuedDataAndReturnsEnvelope()
+    public function testEnqueuePutsMessageEnqueuedDataAndReturnsEnvelope() : void
     {
         $this->wrapped->expects($this->once())
             ->method('enqueue')
@@ -47,7 +47,10 @@ class MetricsDriverIntegrationTest extends TestCase
         $this->assertNoErrors();
     }
 
-    public static function finishers()
+    /**
+     * @return interable<string[]>
+     */
+    public static function finishers() : iterable
     {
         return [
             ['ack'],
@@ -59,7 +62,7 @@ class MetricsDriverIntegrationTest extends TestCase
     /**
      * @dataProvider finishers
      */
-    public function testDequeuingAMessageAndFinishingItInSomeWayTracksMetrics($finish)
+    public function testDequeuingAMessageAndFinishingItInSomeWayTracksMetrics(string $finish) : void
     {
         $this->wrapped->expects($this->once())
             ->method('dequeue')
@@ -76,7 +79,7 @@ class MetricsDriverIntegrationTest extends TestCase
         $this->assertNoErrors();
     }
 
-    public function testRetryReturnsTheEnvelopeFromTheTheWrappedDriver()
+    public function testRetryReturnsTheEnvelopeFromTheTheWrappedDriver() : void
     {
         $this->wrapped->expects($this->once())
             ->method('dequeue')

--- a/test/Test/CollectingLogger.php
+++ b/test/Test/CollectingLogger.php
@@ -12,23 +12,33 @@
 
 namespace PMG\Queue\CloudWatch\Test;
 
+use ArrayIterator;
 use Psr\Log\AbstractLogger;
 
 final class CollectingLogger extends AbstractLogger implements \Countable, \IteratorAggregate
 {
-    private $messages = [];
+    /**
+     * @var string[]
+     */
+    private array $messages = [];
 
-    public function getIterator()
+    /**
+     * @return string[]
+     */
+    public function getIterator() : ArrayIterator
     {
-        return new \ArrayIterator($this->messages);
+        return new ArrayIterator($this->messages);
     }
 
-    public function getMessages()
+    /**
+     * @return string[]
+     */
+    public function getMessages() : array
     {
         return $this->messages;
     }
 
-    public function count()
+    public function count() : int
     {
         return count($this->messages);
     }
@@ -36,11 +46,11 @@ final class CollectingLogger extends AbstractLogger implements \Countable, \Iter
     /**
      * {@inheritdoc}
      */
-    public function log($level, $message, array $context=[])
+    public function log($level, $message, array $context=[]) : void
     {
         $replace = [];
         foreach ($context as $k => $v) {
-            $replace['{'.$k.'}'] = $v;
+            $replace['{'.$k.'}'] = is_scalar($v) ? (string) $v : get_debug_type($v);
         }
 
         $this->messages[] = sprintf('[%s] %s', $level, strtr($message, $replace));

--- a/var/localstack/.gitignore
+++ b/var/localstack/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Also run tests on github actions and use localstack for integration tests.

In general this was mostly about tightening up parameter, property, and return types.